### PR TITLE
Feat: Add hanging commas to the linting rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,13 @@
 	"extends": "fullstack",
 	"rules": {
 		"semi": 0,
-		"new-cap": [1, { "capIsNewExceptions": ["Router"] }]
+    "new-cap": [1, { "capIsNewExceptions": ["Router"] }],
+    "comma-dangle": ["warn", {
+      "arrays": "always",
+      "objects": "always",
+      "imports": "always",
+      "exports": "always",
+      "functions": "ignore"
+    }]
 	}
 }


### PR DESCRIPTION
I'm making this change because I am of the firm belief that having
hanging commas are a helpful feature

### Assignee Tasks

- [x] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)

