### PR TITLE
fix: Properlly associate Group models

### DIFF
--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -17,7 +17,7 @@ Story.hasMany(Comment);
 Comment.belongsTo(Story);
 
 User.belongsToMany(Group, {through: 'UserGroup', });
-Group.hasMany(User);
+Group.belongsToMany(User, {through: 'UserGroup', });
 
 Story.hasMany(Media);
 Media.belongsTo(Story);


### PR DESCRIPTION
There was an error in the associations on the Group model.

### Assignee Tasks

- [x] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)

There was an incorrect association created using 'hasMany'
