### PR TITLE
fix: getMediaUrl will throw error

### DIFF
--- a/client/utils/s3Utils.js
+++ b/client/utils/s3Utils.js
@@ -30,13 +30,15 @@ const addBlobToS3 = (blob, extension) => {
   a promise for a possibly temporary url.
   DRY FTW!
  */
-const getMediaUrl = async (keyOrUrl = '') => {
-  if (keyOrUrl.startsWith('http:') || keyOrUrl.startsWith('https:')){
-    return keyOrUrl
+const getMediaUrl = async keyOrUrl => {
+  if (keyOrUrl === '') {
+    throw new Error('keyOrUrl cannot be empty');
   }
-  else {
-    const s3Url = await Storage.get(keyOrUrl)
-    return s3Url
+  if (keyOrUrl.startsWith('http:') || keyOrUrl.startsWith('https:')) {
+    return keyOrUrl;
+  } else {
+    const s3Url = await Storage.get(keyOrUrl);
+    return s3Url;
   }
 };
 


### PR DESCRIPTION
getMediaUrl was accepting empty key or url.
it will now throw an error if that is teh case.

### Assignee Tasks

- [x] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)


