### PR TITLE
fix: Resolve a few recorder related bugs

### DIFF
--- a/client/components/recorder.js
+++ b/client/components/recorder.js
@@ -23,6 +23,7 @@ class Recorder extends React.Component {
       intervalID: null,
       isPaused: false,
       isRecording: false,
+      isLoaded: false,
     };
     this.animationId = null;
     this.getAudio = this.getAudio.bind(this);
@@ -43,8 +44,13 @@ class Recorder extends React.Component {
     canvasCtx.fillStyle = `rgb(${red}, ${green}, ${blue})`;
     canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
   }
+  componentWillMount() {
+    setTimeout(() => {
+      this.setState({ isLoaded: true, });
+    }, 200);
+  }
   componentDidMount() {
-    if (this.props.isLoggedIn) this.clearCanvas();
+    this.clearCanvas();
   }
   setUpVisualizer(analyser) {
     const canvas = this.recorderVisualizer;
@@ -100,7 +106,7 @@ class Recorder extends React.Component {
           // Create a MediaStreamAudioSourceNode
           // Feed the HTMLMediaElement into it
           var audioCtx = new AudioContext();
-          window.audio = audioCtx //global access to the audio context for play/pause
+          window.audio = audioCtx; //global access to the audio context for play/pause
           var source = audioCtx.createMediaStreamSource(stream);
           this.analyser = audioCtx.createAnalyser();
           const configs = {
@@ -122,7 +128,6 @@ class Recorder extends React.Component {
           recorder.onComplete = (rec, blob) => {
             this.recording = blob;
             this.setState({ isRecording: true, });
-
           };
         });
     } else {
@@ -140,9 +145,9 @@ class Recorder extends React.Component {
     const milisecs = (time - Math.floor(time)).toFixed(5) * 1000;
     const recordingTime = `${minutes}:${
       seconds < 10 ? '0' + seconds : seconds
-      }.${milisecs < 100 ? '0' : ''}${
+    }.${milisecs < 100 ? '0' : ''}${
       milisecs < 10 ? '0' : ''
-      }${milisecs} ${msg}`.trim();
+    }${milisecs} ${msg}`.trim();
     this.setState({ recordingTime, });
   }
   handleStartRecording() {
@@ -155,7 +160,7 @@ class Recorder extends React.Component {
       Recorder.recordingError('Unable to start recording');
     }
   }
-  countDown = (secs) => {
+  countDown = secs => {
     if (secs === -1) {
       this.audioSrc.connect(this.analyser); //new
       this.setUpVisualizer(this.analyser);
@@ -179,16 +184,17 @@ class Recorder extends React.Component {
         this.countDown(secs - 1);
       }, 1000);
     }
-  }
+  };
 
-  handlePauseRecording() { //TODO
-    this.setState({ isPaused: true, })
-    window.audio.suspend()
+  handlePauseRecording() {
+    //TODO
+    this.setState({ isPaused: true, });
+    window.audio.suspend();
   }
 
   handleResumeRecording() {
-    this.setState({ isPaused: false, }) //TODO
-    window.audio.resume()
+    this.setState({ isPaused: false, }); //TODO
+    window.audio.resume();
   }
 
   handleResetRecording() {
@@ -219,9 +225,10 @@ class Recorder extends React.Component {
       <div>
         <div>
           <div
-id="fadeVisualizer" style={this.state.isRecording ? { opacity: '0', } : { opacity: '1', }}
+            id="fadeVisualizer"
+            style={this.state.isRecording ? { opacity: '0', } : { opacity: '1', }}
           >
-            <h2 >{this.state.recordingTime}</h2>
+            <h2>{this.state.recordingTime}</h2>
             <div>
               <canvas
                 className="visualizer"
@@ -234,45 +241,75 @@ id="fadeVisualizer" style={this.state.isRecording ? { opacity: '0', } : { opacit
             </div>
           </div>
 
-              <div>
-                <div id = "fady" style = {this.state.isRecording ? {opacity: '0', } : {opacity: '1', }}>
-                  <button
-                    className="recorderBtn" onClick={() => {
-                      this.props.isLoggedIn ?
-                        this.handleStartRecording()
-                        :
-                        this.props.history.push('/loginModal')
-                    }}>Start</button>
-                  {
-                    this.state.isPaused ?
-                      <button className="recorderBtn" onClick={this.handleResumeRecording}>Resume</button>
-                      :
-                      <button className="recorderBtn" onClick={this.handlePauseRecording}>Pause</button>
-                  }
-                  <button className="recorderBtn" onClick={this.handleStopRecording}>Stop</button>
-                </div>
-                {this.props.isLoggedIn ? '' : <LoginOrSignupModal />}
-              </div>
-
+          <div>
+            <div
+              id="fady"
+              style={
+                this.state.isRecording ? { opacity: '0', } : { opacity: '1', }
+              }
+            >
+              <button
+                className="recorderBtn"
+                onClick={() => {
+                  this.props.isLoggedIn
+                    ? this.handleStartRecording()
+                    : this.props.history.push('/loginModal');
+                }}
+              >
+                Start
+              </button>
+              {this.state.isPaused ? (
+                <button
+                  className="recorderBtn"
+                  onClick={this.handleResumeRecording}
+                >
+                  Resume
+                </button>
+              ) : (
+                <button
+                  className="recorderBtn"
+                  onClick={this.handlePauseRecording}
+                >
+                  Pause
+                </button>
+              )}
+              <button
+                className="recorderBtn"
+                onClick={this.handleStopRecording}
+              >
+                Stop
+              </button>
+            </div>
+            {!this.state.isLoaded || this.props.isLoggedIn ? (
+              ''
+            ) : (
+              <LoginOrSignupModal />
+            )}
+          </div>
         </div>
-        <div id="playbackWaveform" style={this.state.isRecording ? { opacity: '1', } : { opacity: '0', }}>
-
+        <div
+          id="playbackWaveform"
+          style={this.state.isRecording ? { opacity: '1', } : { opacity: '0', }}
+        >
           {this.state.isRecording ? (
             <div id="playbackWaveformPlusBtns">
               <div className="arrowBtnFlex record">
-
-                <button className="addBtn record" onClick={() => { }}>          <img className="recorderArrow" src="/arrowLefty.png" />
-                  Return</button>
+                <button className="addBtn record" onClick={() => {}}>
+                  {' '}
+                  <img className="recorderArrow" src="/arrowLefty.png" />
+                  Return
+                </button>
               </div>
-              <RecorderPlaybackSubmit storySrc={this.recording} history={this.props.history} />
+              <RecorderPlaybackSubmit
+                storySrc={this.recording}
+                history={this.props.history}
+              />
               <div className="arrowBtnFlex record">
-
-                <button className="addBtn record" onClick={() => { }}>Editor
-
-          <img className="recorderArrow" src="/arrowRighty.png" /></button>
+                <button className="addBtn record" onClick={() => {}}>
+                  Editor
+                  <img className="recorderArrow" src="/arrowRighty.png" />
+                </button>
               </div>
-
-
             </div>
           ) : null}
         </div>

--- a/client/components/recorderPlaybackSubmit.js
+++ b/client/components/recorderPlaybackSubmit.js
@@ -28,6 +28,7 @@ class RecorderPlaybackSubmit extends React.Component {
       currentMedia: {},
       name: '',
       genre: '',
+      ready: false,
     };
     this.handleWaveformHover = this.handleWaveformHover.bind(this);
     this.handleChange = this.handleChange.bind(this);
@@ -53,8 +54,11 @@ class RecorderPlaybackSubmit extends React.Component {
       barWidth: 2,
     });
     this.wavesurfer.loadBlob(this.props.storySrc);
+    this.wavesurfer.on('ready', () => this.setState({ready: true, }))
   }
-
+  componentWillUnmount(){
+    this.wavesurfer.unAll()
+  }
   static pointAdder(event) {
     let point = document.createElement('div');
     point.className = 'point';
@@ -133,7 +137,7 @@ class RecorderPlaybackSubmit extends React.Component {
             {this.state.hoverProgress}
           </div>
           <div id="playerControlPanel">
-            <AudioControls audio={this.wavesurfer} />
+            { this.state.ready ? <AudioControls audio={this.wavesurfer} /> : <h1>loading</h1>}
           </div>
         </div>
         <div>


### PR DESCRIPTION
- Closes #46 found a bug where audio controls were rendering prior to
  the waveform completing it's load.
- The recorder is no longer yellow on a refresh.
- The modal `login is required` no longer flashes on a refresh.

- [x] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)

